### PR TITLE
Refactor into reusable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ Binding Kolmogorov complexity and variational free energy along a single bit-axi
    ```
 2. Run the toy compression script:
    ```bash
-   python src/main.py
+   PYTHONPATH=src python -m kc_fep_poc
    ```
    The script simulates a binary sensor stream, fits a Bernoulli model by maximum likelihood and reports the predicted metrics `G_T` and `\rho_T` alongside the LZMA baseline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kc_fep_poc"
+version = "0.1.0"
+description = "Kolmogorov-complexity × Free-Energy toy demo"
+authors = [{name = "Anonymous"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = ["numpy"]

--- a/src/kc_fep_poc/__init__.py
+++ b/src/kc_fep_poc/__init__.py
@@ -1,0 +1,13 @@
+"""Kolmogorov-complexity and Free-Energy toy module."""
+
+from .metrics import (
+    Metrics,
+    compute_metrics,
+    generate_observations,
+)
+
+__all__ = [
+    "Metrics",
+    "compute_metrics",
+    "generate_observations",
+]

--- a/src/kc_fep_poc/__main__.py
+++ b/src/kc_fep_poc/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/kc_fep_poc/cli.py
+++ b/src/kc_fep_poc/cli.py
@@ -1,0 +1,23 @@
+"""Command-line interface for the toy compression demo."""
+from .metrics import generate_observations, compute_metrics
+
+
+def main() -> None:
+    num_steps = 1000
+    true_p = 0.3
+    obs = generate_observations(num_steps, true_p)
+    # MLE estimate
+    mle_p = float(obs.mean())
+    metrics = compute_metrics(obs, mle_p)
+    print("Observations:", num_steps)
+    print("True p:", true_p)
+    print("MLE p:", mle_p)
+    print("K_lzma (bits):", metrics.k_lzma)
+    print("K_hat (bits):", metrics.k_hat)
+    print("Compression gap G_T:", metrics.g_t)
+    print("Free energy F_T:", metrics.free_energy)
+    print("Bit-elasticity rho_T:", metrics.rho_t)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kc_fep_poc/metrics.py
+++ b/src/kc_fep_poc/metrics.py
@@ -36,6 +36,7 @@ class Metrics:
 
 
 def compute_metrics(obs: np.ndarray, model_p: float) -> Metrics:
+    """Compute compression and free-energy metrics."""
     nll = compute_nll(obs, model_p)
     k_hat = compression_bound(nll, model_p)
     k_lzma = lzma_size_bits(obs)
@@ -44,24 +45,3 @@ def compute_metrics(obs: np.ndarray, model_p: float) -> Metrics:
     free_energy = nll
     rho_t = free_energy / g_t if g_t != 0 else float('inf')
     return Metrics(g_t, rho_t, k_hat, k_lzma, free_energy)
-
-
-def main():
-    num_steps = 1000
-    true_p = 0.3
-    obs = generate_observations(num_steps, true_p)
-    # MLE estimate
-    mle_p = float(obs.mean())
-    metrics = compute_metrics(obs, mle_p)
-    print("Observations:", num_steps)
-    print("True p:", true_p)
-    print("MLE p:", mle_p)
-    print("K_lzma (bits):", metrics.k_lzma)
-    print("K_hat (bits):", metrics.k_hat)
-    print("Compression gap G_T:", metrics.g_t)
-    print("Free energy F_T:", metrics.free_energy)
-    print("Bit-elasticity rho_T:", metrics.rho_t)
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from kc_fep_poc.metrics import compute_metrics, generate_observations
+
+
+def test_metrics_runs():
+    obs = generate_observations(10, 0.5)
+    metrics = compute_metrics(obs, 0.5)
+    assert metrics.k_lzma > 0
+    assert metrics.k_hat > 0


### PR DESCRIPTION
## Summary
- turn the `src` script into a `kc_fep_poc` package
- provide a CLI module under `python -m kc_fep_poc`
- add pyproject for package metadata
- update README with new run instructions
- add basic unit test

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m kc_fep_poc | head`

------
https://chatgpt.com/codex/tasks/task_e_686aaa3ca2148331adacea14cf789a9c