### PR TITLE
Configure offline pre-commit and CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -e .
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run tests
+        run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: local
+    hooks:
+      - id: isort
+        name: isort
+        entry: isort
+        language: system
+        types: [python]
+
+      - id: black
+        name: black
+        entry: black
+        language: system
+        types: [python]
+
+      - id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        args: ["--max-line-length=88"]
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Binding Kolmogorov complexity and variational free energy along a single bit-axi
 
 ---
 
+## Setup
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install   # one-time
+```
+
 ## Running the Example
 
 1. Install dependencies (Python 3.8+ recommended):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,9 @@ authors = [{name = "Anonymous"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = ["numpy"]
+
+[tool.isort]
+profile = "black"
+
+[tool.black]
+line-length = 88

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+black==23.7.0
+isort==5.12.0
+flake8==6.1.0
+pre-commit==3.3.3
+pytest==7.4.0

--- a/src/kc_fep_poc/__init__.py
+++ b/src/kc_fep_poc/__init__.py
@@ -1,11 +1,7 @@
 """Kolmogorov-complexity and Free-Energy toy module."""
 
-from .metrics import (
-    Metrics,
-    compute_metrics,
-    generate_observations,
-)
 from .dataset import write_dataset
+from .metrics import Metrics, compute_metrics, generate_observations
 
 __all__ = [
     "Metrics",

--- a/src/kc_fep_poc/cli.py
+++ b/src/kc_fep_poc/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface for the toy compression demo."""
-from .metrics import generate_observations, compute_metrics
+
+from .metrics import compute_metrics, generate_observations
 
 
 def main() -> None:

--- a/src/kc_fep_poc/dataset.py
+++ b/src/kc_fep_poc/dataset.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from pathlib import Path
 import argparse
+from pathlib import Path
 
 from .metrics import generate_observations
-
 
 DEFAULT_STEPS = 4096
 DEFAULT_RUNS = 100
 P_VALUES = [round(i / 10, 1) for i in range(1, 10)]
 
 
-def write_dataset(output_dir: str | Path,
-                  steps: int = DEFAULT_STEPS,
-                  runs: int = DEFAULT_RUNS) -> None:
+def write_dataset(
+    output_dir: str | Path, steps: int = DEFAULT_STEPS, runs: int = DEFAULT_RUNS
+) -> None:
     """Write binary observation files for a range of Bernoulli parameters.
 
     Parameters
@@ -40,8 +39,12 @@ def write_dataset(output_dir: str | Path,
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Generate binary Bernoulli dataset")
-    parser.add_argument("output", nargs="?", default="dataset",
-                        help="directory to store generated files")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="dataset",
+        help="directory to store generated files",
+    )
     args = parser.parse_args(argv)
     write_dataset(args.output)
 

--- a/src/kc_fep_poc/metrics.py
+++ b/src/kc_fep_poc/metrics.py
@@ -1,6 +1,7 @@
 import lzma
-import numpy as np
 from dataclasses import dataclass
+
+import numpy as np
 
 
 def generate_observations(num_steps: int, p: float) -> np.ndarray:
@@ -17,7 +18,7 @@ def compute_nll(obs: np.ndarray, p: float) -> float:
 
 def compression_bound(nll_bits: float, theta: float) -> float:
     """Two-part code bound from README eq. (1)."""
-    return theta ** 2 * np.log(2) + nll_bits
+    return theta**2 * np.log(2) + nll_bits
 
 
 def lzma_size_bits(obs: np.ndarray) -> int:
@@ -43,5 +44,5 @@ def compute_metrics(obs: np.ndarray, model_p: float) -> Metrics:
     g_t = k_lzma - k_hat
     # For this simple model free energy equals nll (accuracy term) as we ignore KL
     free_energy = nll
-    rho_t = free_energy / g_t if g_t != 0 else float('inf')
+    rho_t = free_energy / g_t if g_t != 0 else float("inf")
     return Metrics(g_t, rho_t, k_hat, k_lzma, free_energy)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from kc_fep_poc.dataset import write_dataset
+from kc_fep_poc.dataset import write_dataset  # noqa: E402
 
 
 def test_write_dataset(tmp_path: Path):
@@ -16,4 +16,3 @@ def test_write_dataset(tmp_path: Path):
     # check a single file length
     sample_file = next(dirs[0].iterdir())
     assert sample_file.stat().st_size == 4096
-

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,9 +1,10 @@
 import os
 import sys
-import numpy as np
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-from kc_fep_poc.metrics import compute_metrics, generate_observations
+
+from kc_fep_poc.metrics import compute_metrics  # noqa: E402
+from kc_fep_poc.metrics import generate_observations  # noqa: E402
 
 
 def test_metrics_runs():


### PR DESCRIPTION
## Summary
- add local pre-commit hooks for isort, black and flake8
- configure flake8
- pin dev requirements
- document setup instructions in README
- enforce formatting and linting in CI
- apply formatting fixes

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac51c3a248331b75b6a92528f15bc