### PR TITLE
Add deterministic seed option for dataset generation

### DIFF
--- a/src/kc_fep_poc/metrics.py
+++ b/src/kc_fep_poc/metrics.py
@@ -4,9 +4,24 @@ from dataclasses import dataclass
 import numpy as np
 
 
-def generate_observations(num_steps: int, p: float) -> np.ndarray:
-    """Simulate binary observations from Bernoulli(p)."""
-    return np.random.binomial(1, p, size=num_steps).astype(np.uint8)
+def generate_observations(
+    num_steps: int, p: float, rng: np.random.Generator | None = None
+) -> np.ndarray:
+    """Simulate binary observations from Bernoulli(p).
+
+    Parameters
+    ----------
+    num_steps : int
+        Number of observations to generate.
+    p : float
+        Bernoulli success probability.
+    rng : numpy.random.Generator, optional
+        Random number generator to use. If omitted, ``numpy.random.default_rng``
+        is used.
+    """
+
+    generator = np.random.default_rng() if rng is None else rng
+    return generator.binomial(1, p, size=num_steps).astype(np.uint8)
 
 
 def compute_nll(obs: np.ndarray, p: float) -> float:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -16,3 +16,13 @@ def test_write_dataset(tmp_path: Path):
     # check a single file length
     sample_file = next(dirs[0].iterdir())
     assert sample_file.stat().st_size == 4096
+
+
+def test_write_dataset_seed_reproducible(tmp_path: Path):
+    d1 = tmp_path / "d1"
+    d2 = tmp_path / "d2"
+    write_dataset(d1, steps=16, runs=1, seed=123)
+    write_dataset(d2, steps=16, runs=1, seed=123)
+    f1 = d1 / "p0.1" / "run_000.bin"
+    f2 = d2 / "p0.1" / "run_000.bin"
+    assert f1.read_bytes() == f2.read_bytes()


### PR DESCRIPTION
## Summary
- allow passing a seed to `write_dataset`
- expose seed parameter from CLI
- support RNG injection in `generate_observations`
- test dataset reproducibility when seed is provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac80386c08331a5abfc0fe1bf19d0