### PR TITLE
Switch dataset writing to numpy tofile

### DIFF
--- a/src/kc_fep_poc/dataset.py
+++ b/src/kc_fep_poc/dataset.py
@@ -45,7 +45,7 @@ def write_dataset(
             rng = np.random.default_rng(run_seed)
             obs = generate_observations(steps, p, rng)
             filename = subdir / f"run_{i:03d}.bin"
-            filename.write_bytes(bytes(obs))
+            obs.tofile(filename)
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- use `numpy.ndarray.tofile` when saving observation sequences

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac9ced2ec8331ac4c99885b43d974