### PR TITLE
Add async LZMA metric computation

### DIFF
--- a/src/kc_fep_poc/metrics.py
+++ b/src/kc_fep_poc/metrics.py
@@ -1,5 +1,6 @@
 import lzma
 from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 
@@ -39,6 +40,12 @@ def compression_bound(nll_bits: float, theta: float) -> float:
 def lzma_size_bits(obs: np.ndarray) -> int:
     """Compress using LZMA and return size in bits."""
     data = bytes(obs)
+    return len(lzma.compress(data)) * 8
+
+
+def bits_lzma(path: str | Path) -> int:
+    """Return size in bits of ``path`` compressed with LZMA."""
+    data = Path(path).read_bytes()
     return len(lzma.compress(data)) * 8
 
 

--- a/src/kc_fep_poc/orchestrator.py
+++ b/src/kc_fep_poc/orchestrator.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import csv
 from dataclasses import dataclass
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
 
-from .metrics import Metrics
+from .metrics import Metrics, bits_lzma
 
 
 @dataclass
@@ -46,7 +47,7 @@ def run(
     csv_file = Path(settings.csv_path)
     csv_file.parent.mkdir(parents=True, exist_ok=True)
 
-    with csv_file.open("w", newline="") as f:
+    with csv_file.open("w", newline="") as f, ThreadPoolExecutor() as pool:
         writer = csv.writer(f)
         writer.writerow(
             [
@@ -59,18 +60,37 @@ def run(
             ]
         )
 
+        pending: list[tuple[int, Metrics, object]] = []
+
         for episode in range(settings.episodes):
-            metrics: Metrics = env_wrapper.run_episode(agent, binary_logger)
-            results.append(metrics)
-            writer.writerow(
-                [
-                    episode,
-                    metrics.g_t,
-                    metrics.rho_t,
-                    metrics.k_hat,
-                    metrics.k_lzma,
-                    metrics.free_energy,
-                ]
-            )
+            result = env_wrapper.run_episode(agent, binary_logger)
+            if isinstance(result, tuple):
+                metrics, obs_file = result
+                future = pool.submit(bits_lzma, obs_file)
+            else:
+                metrics = result
+                future = None
+
+            pending.append((episode, metrics, future))
+
+            i = 0
+            while i < len(pending):
+                ep, m, fut = pending[i]
+                if fut is None or fut.done():
+                    if fut is not None:
+                        m.k_lzma = fut.result()
+                    results.append(m)
+                    writer.writerow(
+                        [ep, m.g_t, m.rho_t, m.k_hat, m.k_lzma, m.free_energy]
+                    )
+                    pending.pop(i)
+                else:
+                    i += 1
+
+        for ep, m, fut in pending:
+            if fut is not None:
+                m.k_lzma = fut.result()
+            results.append(m)
+            writer.writerow([ep, m.g_t, m.rho_t, m.k_hat, m.k_lzma, m.free_energy])
 
     return results

--- a/src/kc_fep_poc/orchestrator.py
+++ b/src/kc_fep_poc/orchestrator.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 """Training orchestrator tying together environment, logger and agent."""
 
 import csv
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from concurrent.futures import ThreadPoolExecutor
 
 from .metrics import Metrics, bits_lzma
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,8 +6,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-from kc_fep_poc.metrics import compute_metrics  # noqa: E402
-from kc_fep_poc.metrics import generate_observations  # noqa: E402
+from kc_fep_poc.metrics import bits_lzma, compute_metrics  # noqa: E402
+from kc_fep_poc.metrics import generate_observations, lzma_size_bits  # noqa: E402
 
 
 def test_metrics_runs():
@@ -31,3 +31,10 @@ def test_generate_observations_deterministic_seed():
     obs1 = generate_observations(50, p, np.random.default_rng(seed))
     obs2 = generate_observations(50, p, np.random.default_rng(seed))
     assert np.array_equal(obs1, obs2)
+
+
+def test_bits_lzma_file(tmp_path):
+    obs = generate_observations(32, 0.5)
+    f = tmp_path / "obs.bin"
+    obs.tofile(f)
+    assert bits_lzma(f) == lzma_size_bits(obs)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,8 +6,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-from kc_fep_poc.metrics import bits_lzma, compute_metrics  # noqa: E402
-from kc_fep_poc.metrics import generate_observations, lzma_size_bits  # noqa: E402
+from kc_fep_poc.metrics import (  # noqa: E402
+    bits_lzma,
+    compute_metrics,
+    generate_observations,
+    lzma_size_bits,
+)
 
 
 def test_metrics_runs():


### PR DESCRIPTION
## Summary
- add `bits_lzma` helper for file-based compression size
- asynchronously compute LZMA bits in `orchestrator.run`
- test `bits_lzma`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aeae0ec188331b02c89bc2983e705