### PR TITLE
Add experiment log validator

### DIFF
--- a/src/kc_fep_poc/validator.py
+++ b/src/kc_fep_poc/validator.py
@@ -1,0 +1,56 @@
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from .metrics import compute_metrics
+
+
+def validate(csv_path: str | Path, base_dir: str | Path | None = None) -> bool:
+    csv_path = Path(csv_path)
+    if base_dir is None:
+        base_dir = csv_path.parent
+    base_dir = Path(base_dir)
+
+    g_vals: list[float] = []
+    f_vals: list[float] = []
+
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        if "file" not in reader.fieldnames:
+            raise ValueError("CSV must contain 'file' column")
+
+        for row in reader:
+            file_path = base_dir / row["file"]
+            obs = np.fromfile(file_path, dtype=np.uint8)
+            m = compute_metrics(obs, float(obs.mean()))
+            if m.k_hat > m.k_lzma:
+                return False
+            g_vals.append(m.g_t)
+            f_vals.append(m.free_energy)
+
+    if len(g_vals) < 2:
+        return False
+
+    r = float(np.corrcoef(g_vals, f_vals)[0, 1])
+    if np.isnan(r) or r < 0.9:
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate experiment logs")
+    parser.add_argument("csv", help="metrics CSV file")
+    parser.add_argument(
+        "--base", help="base directory for observation files", default=None
+    )
+    args = parser.parse_args(argv)
+
+    ok = validate(args.csv, args.base)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,37 @@
+import csv
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import numpy as np  # noqa: E402
+
+from kc_fep_poc.metrics import compute_metrics, generate_observations  # noqa: E402
+from kc_fep_poc.validator import validate  # noqa: E402
+
+
+def test_validator_passes(tmp_path: Path) -> None:
+    rng = np.random.default_rng(2)
+    csv_path = tmp_path / "metrics.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "episode",
+            "g_t",
+            "rho_t",
+            "k_hat",
+            "k_lzma",
+            "free_energy",
+            "file",
+        ])
+        for ep, p in enumerate([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]):
+            obs = generate_observations(1000, p, rng)
+            file = tmp_path / f"ep_{ep}.bin"
+            obs.tofile(file)
+            m = compute_metrics(obs, p)
+            writer.writerow(
+                [ep, m.g_t, m.rho_t, m.k_hat, m.k_lzma, m.free_energy, file.name]
+            )
+
+    assert validate(csv_path, base_dir=tmp_path)


### PR DESCRIPTION
## Summary
- implement `validator` module for checking experiment logs
- compute metrics from observation files, check KC bounds and correlation
- add tests generating a tiny dataset and validating it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aefcc3020833186bb6e111d2f89f0