### PR TITLE
Add experiment CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ The difference between the compressor’s length and the agent’s length is the
 Three predictions follow from this setup. First, the compression gap should never shrink for long once learning begins. A steady decline would suggest the model is failing to capture structure. Second, the better the compression gets, the more the free-energy score should drop—the two numbers should move together. Third, after enough experience in a stable environment, the agent’s description of the data should be shorter than the one produced by the compressor.
 
 Confirming these trends would support the idea that active inference not only guides actions but also shortens the algorithmic description of experience. If those trends disappear, we learn that the link may be weaker than theorised. Either outcome delivers a clear, measurable test of the free-energy principle.
+
+## Quick start
+
+1. Create a `config.yml` file describing the experiment. A minimal example:
+
+   ```yaml
+   episodes: 3
+   p: 0.5
+   steps: 128
+   csv_path: metrics.csv
+   ```
+
+2. Run the experiment:
+
+   ```bash
+   kc-fep-run
+   ```
+
+This writes `metrics.csv` and prints a table summarising each episode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = ["numpy"]
 
+[project.scripts]
+"kc-fep-run" = "kc_fep_poc.cli_experiment:main"
+
 [tool.isort]
 profile = "black"
 

--- a/src/kc_fep_poc/cli_experiment.py
+++ b/src/kc_fep_poc/cli_experiment.py
@@ -1,0 +1,65 @@
+"""Command-line experiment runner using :mod:`kc_fep_poc.orchestrator`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from .metrics import compute_metrics, generate_observations
+from .orchestrator import Settings, run
+
+
+class BernoulliEnvWrapper:
+    """Toy environment producing Bernoulli observations."""
+
+    def __init__(self, p: float, steps: int, seed: int | None = None) -> None:
+        import numpy as np
+
+        self.p = p
+        self.steps = steps
+        self.rng = np.random.default_rng(seed)
+
+    def run_episode(self, agent: object, binary_logger: object) -> object:
+        obs = generate_observations(self.steps, self.p, self.rng)
+        m = compute_metrics(obs, float(obs.mean()))
+        return m
+
+
+def _print_table(metrics: list) -> None:
+    header = ("episode", "g_t", "rho_t", "k_hat", "k_lzma", "free_energy")
+    print(
+        f"{header[0]:>7} {header[1]:>10} {header[2]:>10} "
+        f"{header[3]:>10} {header[4]:>10} {header[5]:>12}"
+    )
+    for i, m in enumerate(metrics):
+        print(
+            f"{i:7d} {m.g_t:10.2f} {m.rho_t:10.2f} "
+            f"{m.k_hat:10.2f} {m.k_lzma:10d} {m.free_energy:12.2f}"
+        )
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run KC-FEP experiment")
+    parser.add_argument("--config", default="config.yml", help="path to config file")
+    args = parser.parse_args(argv)
+
+    cfg = yaml.safe_load(Path(args.config).read_text())
+    episodes = int(cfg.get("episodes", 1))
+    csv_path = cfg.get("csv_path", "metrics.csv")
+    p = float(cfg.get("p", 0.5))
+    steps = int(cfg.get("steps", 128))
+    seed = cfg.get("seed")
+
+    env = BernoulliEnvWrapper(p=p, steps=steps, seed=seed)
+    agent = object()
+    logger = object()
+    settings = Settings(episodes=episodes, csv_path=csv_path)
+
+    metrics = run(env, logger, agent, settings)
+    _print_table(metrics)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add entrypoint for `kc-fep-run`
- implement `cli_experiment.py` to drive orchestrator
- document quick-start usage

## Testing
- `flake8`
- `black --check src/kc_fep_poc/cli_experiment.py`
- `black --check src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686af293072083319297475829686cb7